### PR TITLE
fix typo in check_error method

### DIFF
--- a/lib/eventbrite_api_client.rb
+++ b/lib/eventbrite_api_client.rb
@@ -38,7 +38,7 @@ class EventbriteApiClient
       if !is_json?(response)
         {
           'error' => 'NOT_FOUND',
-          'error_description' => 'That is not a valid api endpoitn',
+          'error_description' => 'That is not a valid api endpoint',
           'status_code' => 404
         }
       else


### PR DESCRIPTION
updated error message to:
'error_description' => 'That is not a valid api endpoint',